### PR TITLE
Resize image don't work with touch screen device #4124

### DIFF
--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -43,7 +43,7 @@ export default class Handle {
       '</div>',
     ].join('')).prependTo(this.$editingArea);
 
-    this.$handle.on('mousedown', (event) => {
+    this.$handle.on('mousedown touchstart', (event) => {
       if (dom.isControlSizing(event.target)) {
         event.preventDefault();
         event.stopPropagation();
@@ -54,18 +54,18 @@ export default class Handle {
 
         const onMouseMove = (event) => {
           this.context.invoke('editor.resizeTo', {
-            x: event.clientX - posStart.left,
-            y: event.clientY - (posStart.top - scrollTop),
+            x: ( event.targetTouches ? event.targetTouches[0].clientX : event.clientX ) - posStart.left,
+            y: ( event.targetTouches ? event.targetTouches[0].clientY : event.clientY ) - (posStart.top - scrollTop),
           }, $target, !event.shiftKey);
 
           this.update($target[0], event);
         };
 
         this.$document
-          .on('mousemove', onMouseMove)
-          .one('mouseup', (e) => {
+          .on('mousemove touchmove', onMouseMove)
+          .one('mouseup touchend', (e) => {
             e.preventDefault();
-            this.$document.off('mousemove', onMouseMove);
+            this.$document.off('mousemove touchmove', onMouseMove);
             this.context.invoke('editor.afterCommand');
           });
 


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- Allow to use module resize image with touch events for mobile device.

#### Where should the reviewer start?

- start on the src/js/base/module/Handle.js

#### How should this be manually tested?

- On touch screen, add image then try to drag the handle with finger to resize the image.

### Checklist

- [x ] tests required (?)
- [x] Didn't break anything
